### PR TITLE
MP-62 Properties From Parent Poms Aren't Used In Regex Activator Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -173,7 +173,6 @@
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
-                        <phase>verify</phase>
                         <goals>
                             <goal>sign</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
                     <localRepositoryPath>${project.build.directory}/.m2/repository</localRepositoryPath>
                     <pomIncludes>
                         <include>activation-it</include>
+                        <include>submodule-it</include>
                     </pomIncludes>
                 </configuration>
                 <executions>

--- a/src/it/submodule-it/.mvn/extensions.xml
+++ b/src/it/submodule-it/.mvn/extensions.xml
@@ -1,0 +1,47 @@
+<!--
+  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+-->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+
+    <extension>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+    </extension>
+
+</extensions>

--- a/src/it/submodule-it/pom.xml
+++ b/src/it/submodule-it/pom.xml
@@ -1,0 +1,60 @@
+<!--
+  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>fish.payara.maven.extensions.test</groupId>
+    <artifactId>submodule-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <magic.file>${project.build.directory}/magic-file</magic.file>
+
+        <property1>abracadabra</property1>
+    </properties>
+
+    <modules>
+        <module>submodule-module</module>
+    </modules>
+
+</project>

--- a/src/it/submodule-it/submodule-module/pom.xml
+++ b/src/it/submodule-it/submodule-module/pom.xml
@@ -1,0 +1,130 @@
+<!--
+  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fish.payara.maven.extensions.test</groupId>
+        <artifactId>submodule-it</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>submodule-module</artifactId>
+    <packaging>pom</packaging>
+
+    <profiles>
+        <profile>
+            <id>abra</id>
+            <activation>
+                <property>
+                    <name>property1</name>
+                    <value>/abra.+/</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-magic-file</id>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <target name="magic-file">
+                                        <echo file="${magic.file}-abra" append="false">${magic.file}-abra</echo>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>delete-magic-file</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <target name="magic-file">
+                                <delete file="${magic.file}-abra" />
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>create-magic-file</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>check-magic-file</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <target name="magic-file">
+                                <!-- Check abra magic file exists -->
+                                <available file="${magic.file}-abra" property="abra.file.exists" />
+                                <fail message="Magic file ${magic.file}-abra missing. The profile probably wasn't activated." unless="abra.file.exists" />
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/main/java/fish/payara/maven/extensions/regex/activator/RegexActivator.java
+++ b/src/main/java/fish/payara/maven/extensions/regex/activator/RegexActivator.java
@@ -157,7 +157,7 @@ public class RegexActivator implements ProfileActivator {
                 // If the pom contains a parent block with a relativePath, use that to
                 // recursively search
                 if (project.getModel() != null && project.getModel().getParent() != null) {
-                    String relativePath = project.getModel().getParent().getRelativePath();
+                    String relativePath = project.getModel().getParent().getRelativePath().replace("pom.xml", "");
                     if (relativePath != null) {
                         return getPropertyFromPom(new File(projectDirectory, relativePath), propertyName);
                     }

--- a/src/main/java/fish/payara/maven/extensions/regex/activator/RegexProfileSelector.java
+++ b/src/main/java/fish/payara/maven/extensions/regex/activator/RegexProfileSelector.java
@@ -81,7 +81,14 @@ public class RegexProfileSelector extends DefaultProfileSelector {
     }
 
     /**
-     * Called instead of parent isActive to make sure that an OR gate is used for profile activation.
+     * Called instead of parent isActive to make sure that an OR gate is used for
+     * profile activation.
+     * 
+     * @param profile  the profile to check
+     * @param context  the environment to use in checking the profile
+     * @param problems aggregator for build problems
+     * 
+     * @return if the profile is active.
      */
     protected boolean isActive(Profile profile, ProfileActivationContext context, ModelProblemCollector problems) {
         boolean isActive = false;


### PR DESCRIPTION
From what I could tell, the function that found the relative path of a parent pom had the possibility of returning in the form `../pom.xml`, which would then be built into a file URL like: `../pom.xml/pom.xml`, which was returning null. This caused parent properties to not be found. I've added a test for this and fixed the issue.