### PR TITLE
Support for activating based on version range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,11 +118,12 @@
                 <artifactId>maven-invoker-plugin</artifactId>
                 <version>3.2.0</version>
                 <configuration>
-                    <!-- <debug>true</debug> -->
                     <goals>
                         <goal>clean</goal>
                         <goal>test</goal>
                     </goals>
+<!--                    <debug>true</debug>-->
+<!--                    <mavenExecutable>mvnDebug</mavenExecutable>-->
                     <showErrors>true</showErrors>
                     <streamLogs>true</streamLogs>
                     <projectsDirectory>${project.basedir}/src/it</projectsDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,10 @@
                 <version>3.2.0</version>
                 <configuration>
                     <!-- <debug>true</debug> -->
+                    <goals>
+                        <goal>clean</goal>
+                        <goal>test</goal>
+                    </goals>
                     <showErrors>true</showErrors>
                     <streamLogs>true</streamLogs>
                     <projectsDirectory>${project.basedir}/src/it</projectsDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
     <groupId>fish.payara.maven.extensions</groupId>
     <artifactId>regex-profile-activator</artifactId>
-    <version>0.3</version>
+    <version>0.4-SNAPSHOT</version>
 
     <name>Regex Profile Activator Maven Extension</name>
     <description>Allow profile activation using regex expressions.</description>

--- a/src/it/activation-it/pom.xml
+++ b/src/it/activation-it/pom.xml
@@ -118,6 +118,68 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>version1</id>
+            <activation>
+                <property>
+                    <name>property2</name>
+                    <value>=[4,)</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-magic-file-version1</id>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <target name="magic-file-version1">
+                                        <echo file="${magic.file}-version1" append="false">${magic.file}-version1</echo>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>version2</id>
+            <activation>
+                <property>
+                    <name>property2</name>
+                    <value>=[4,5.184),(5.184,)</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-magic-file-version2</id>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <target name="magic-file-version2">
+                                        <echo file="${magic.file}-version2" append="false">${magic.file}-version2</echo>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -150,6 +212,12 @@
                                 <!-- Check Payara4 magic file doesn't exist -->
                                 <available file="${magic.file}-payara4" property="payara.file.exists" />
                                 <fail message="Magic file ${magic.file}-payara4 present. The profile was incorrectly activated." if="payara.file.exists" />
+
+                                <available file="${magic.file}-version1" property="version1.file.exists" />
+                                <fail message="Magic file ${magic.file}-version1 missing. The profile probably wasn't activated." unless="version1.file.exists" />
+
+                                <available file="${magic.file}-version2" property="version2.file.exists" />
+                                <fail message="Magic file ${magic.file}-version2 present. The profile probably was incorrectly activated." if="version2.file.exists" />
 
                             </target>
                         </configuration>

--- a/src/it/activation-it/pom.xml
+++ b/src/it/activation-it/pom.xml
@@ -72,9 +72,9 @@
                         <executions>
                             <execution>
                                 <id>create-magic-file</id>
-                                <phase>validate</phase>
+                                <phase>compile</phase>
                                 <configuration>
-                                    <target name="magic-file">
+                                    <target name="magic-file-abra">
                                         <echo file="${magic.file}-abra" append="false">${magic.file}-abra</echo>
                                     </target>
                                 </configuration>
@@ -103,9 +103,9 @@
                         <executions>
                             <execution>
                                 <id>create-magic-file</id>
-                                <phase>validate</phase>
+                                <phase>compile</phase>
                                 <configuration>
-                                    <target name="magic-file">
+                                    <target name="magic-file-payara4">
                                         <echo file="${magic.file}-payara4" append="false">${magic.file}-payara4</echo>
                                     </target>
                                 </configuration>
@@ -129,11 +129,10 @@
                 <executions>
                     <execution>
                         <id>delete-magic-file</id>
-                        <phase>validate</phase>
+                        <phase>clean</phase>
                         <configuration>
                             <target name="magic-file">
-                                <delete file="${magic.file}-abra" />
-                                <delete file="${magic.file}-payara4" />
+                                <delete file="${magic.file}-*" />
                             </target>
                         </configuration>
                         <goals>
@@ -141,15 +140,8 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>create-magic-file</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                    <execution>
                         <id>check-magic-file</id>
-                        <phase>validate</phase>
+                        <phase>test</phase>
                         <configuration>
                             <target name="magic-file">
                                 <!-- Check abra magic file exists -->
@@ -157,7 +149,8 @@
                                 <fail message="Magic file ${magic.file}-abra missing. The profile probably wasn't activated." unless="abra.file.exists" />
                                 <!-- Check Payara4 magic file doesn't exist -->
                                 <available file="${magic.file}-payara4" property="payara.file.exists" />
-                                <fail message="Magic file ${magic.file}-payara4 missing. The profile probably wasn't activated." if="payara.file.exists" />
+                                <fail message="Magic file ${magic.file}-payara4 present. The profile was incorrectly activated." if="payara.file.exists" />
+
                             </target>
                         </configuration>
                         <goals>

--- a/src/it/project-property-it/pom.xml
+++ b/src/it/project-property-it/pom.xml
@@ -51,7 +51,7 @@
 
         <magic.file>${project.build.directory}/magic-file</magic.file>
         <magic.file2>${project.build.directory}/magic-file2</magic.file2>
-        <magic.file2>${project.build.directory}/magic-file3</magic.file2>
+        <magic.file3>${project.build.directory}/magic-file3</magic.file3>
 
         <versionproperty>${project.version}</versionproperty>
         <badproperty>${project.doesntexist}</badproperty>
@@ -119,11 +119,71 @@
             </build>
         </profile>
         <profile>
+            <id>should-also-activate-version</id>
+            <activation>
+                <property>
+                    <name>versionproperty</name>
+                    <value>=[1.0-SNAPSHOT,)</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-magic-file-version2</id>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <target name="magic-file-version2">
+                                        <echo file="${magic.file2}-version" append="false">${magic.file2}</echo>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>should-not-activate</id>
             <activation>
                 <property>
                     <name>${badproperty}</name>
                     <value>/1.+/</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-magic-file3</id>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <target name="magic-file3">
+                                        <echo file="${magic.file3}" append="false">${magic.file3}</echo>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>should-not-activate-version</id>
+            <activation>
+                <property>
+                    <name>badproperty</name>
+                    <value>=[0,)</value>
                 </property>
             </activation>
             <build>
@@ -158,46 +218,20 @@
                 <executions>
                     <execution>
                         <id>delete-magic-file</id>
-                        <phase>validate</phase>
+                        <phase>clean</phase>
                         <configuration>
                             <target name="magic-file">
-                                <delete file="${magic.file}" />
-                            </target>
-                            <target name="magic-file2">
-                                <delete file="${magic.file2}" />
-                            </target>
-                            <target name="magic-file3">
-                                <delete file="${magic.file3}" />
+                                <delete file="${magic.file}*" />
                             </target>
                         </configuration>
                         <goals>
                             <goal>run</goal>
                         </goals>
                     </execution>
-                    <execution>
-                        <id>create-magic-file</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>create-magic-file2</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>create-magic-file3</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
+
                     <execution>
                         <id>check-magic-file</id>
-                        <phase>validate</phase>
+                        <phase>test</phase>
                         <configuration>
                             <target name="magic-file">
                                 <!-- Check magic file exists -->
@@ -206,9 +240,13 @@
                                 <!-- Check magic file 2 exists -->
                                 <available file="${magic.file2}" property="magic.file2.exists" />
                                 <fail message="Magic file ${magic.file2} missing. The profile probably wasn't activated." unless="magic.file2.exists" />
+
+                                <available file="${magic.file2}-version" property="magic.file2version.exists" />
+                                <fail message="Magic file ${magic.file2}-version missing. The profile probably wasn't activated." unless="magic.file2version.exists" />
+
                                 <!-- Check magic file 3 doesn't exist -->
                                 <available file="${magic.file3}" property="magic.file3.exists" />
-                                <fail message="Magic file ${magic.file3} missing. The profile probably was activated when it shouldn't have been." if="magic.file3.exists" />
+                                <fail message="Magic file ${magic.file3} present. The profile probably was activated when it shouldn't have been." if="magic.file3.exists" />
                             </target>
                         </configuration>
                         <goals>

--- a/src/it/submodule-it/pom.xml
+++ b/src/it/submodule-it/pom.xml
@@ -51,6 +51,7 @@
         <magic.file>${project.build.directory}/magic-file</magic.file>
 
         <property1>abracadabra</property1>
+        <other.version>5.194-SNAPSHOT</other.version>
     </properties>
 
     <modules>

--- a/src/it/submodule-it/submodule-module/pom.xml
+++ b/src/it/submodule-it/submodule-module/pom.xml
@@ -80,6 +80,99 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>matching-project-version</id>
+            <activation>
+                <property>
+                    <name>project.version</name>
+                    <value>=[1.0-SNAPSHOT,)</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-magic-file-v1</id>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <target name="magic-file-v1">
+                                        <echo file="${magic.file}-v1" append="false">${magic.file}-abra</echo>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>nonmatching-project-version</id>
+            <activation>
+                <property>
+                    <name>project.version</name>
+                    <value>=[1.0,)</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-magic-file-v2</id>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <target name="magic-file-v2">
+                                        <echo file="${magic.file}-v2" append="false">${magic.file}-abra</echo>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>matching-parent-property</id>
+            <activation>
+                <property>
+                    <name>other.version</name>
+                    <value>=[5.193,)</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-magic-file-v3</id>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <target name="magic-file-v3">
+                                        <echo file="${magic.file}-v3" append="false">${magic.file}-abra</echo>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -91,10 +184,10 @@
                 <executions>
                     <execution>
                         <id>delete-magic-file</id>
-                        <phase>validate</phase>
+                        <phase>clean</phase>
                         <configuration>
                             <target name="magic-file">
-                                <delete file="${magic.file}-abra" />
+                                <delete file="${magic.file}*" />
                             </target>
                         </configuration>
                         <goals>
@@ -102,20 +195,23 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>create-magic-file</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                    <execution>
                         <id>check-magic-file</id>
-                        <phase>validate</phase>
+                        <phase>test</phase>
                         <configuration>
-                            <target name="magic-file">
+                            <target name="magic-file-abra">
                                 <!-- Check abra magic file exists -->
                                 <available file="${magic.file}-abra" property="abra.file.exists" />
                                 <fail message="Magic file ${magic.file}-abra missing. The profile probably wasn't activated." unless="abra.file.exists" />
+
+                                <available file="${magic.file}-v1" property="v1.file.exists" />
+                                <fail message="Magic file ${magic.file}-v1 missing. The profile probably wasn't activated." unless="v1.file.exists" />
+
+                                <available file="${magic.file}-v2" property="v2.file.exists" />
+                                <fail message="Magic file ${magic.file}-v2 present. The profile shouldn't have been activated." if="v2.file.exists" />
+
+                                <available file="${magic.file}-v3" property="v3.file.exists" />
+                                <fail message="Magic file ${magic.file}-v3 missing. The profile probably wasn't activated." unless="v3.file.exists" />
+
                             </target>
                         </configuration>
                         <goals>

--- a/src/main/java/fish/payara/maven/extensions/regex/activator/ExtendedProfileSelector.java
+++ b/src/main/java/fish/payara/maven/extensions/regex/activator/ExtendedProfileSelector.java
@@ -52,13 +52,19 @@ import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 
+/**
+ * The profile selector evaluates extension activators in addition to standard ones.
+ * Activator provided in this artifact are combined with condition OR to standard artifacts.
+ * Otherwise, standard property activator kicks in and prevents profile activation, as it requires value to be
+ * equal.
+ */
 @Component(role = ProfileSelector.class, hint = "default")
-public class RegexProfileSelector extends DefaultProfileSelector {
+public class ExtendedProfileSelector extends DefaultProfileSelector {
 
     @Requirement
     private Logger logger;
 
-    @Requirement(role = RegexActivator.class)
+    @Requirement(role = ExtensionActivator.class)
     protected List<ProfileActivator> activatorList = new ArrayList<>();
 
     @Override

--- a/src/main/java/fish/payara/maven/extensions/regex/activator/ExtensionActivator.java
+++ b/src/main/java/fish/payara/maven/extensions/regex/activator/ExtensionActivator.java
@@ -1,0 +1,46 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.maven.extensions.regex.activator;
+
+import org.apache.maven.model.profile.activation.ProfileActivator;
+
+public interface ExtensionActivator extends ProfileActivator {
+}

--- a/src/main/java/fish/payara/maven/extensions/regex/activator/PropertyResolver.java
+++ b/src/main/java/fish/payara/maven/extensions/regex/activator/PropertyResolver.java
@@ -1,0 +1,204 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.maven.extensions.regex.activator;
+
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.model.profile.ProfileActivationContext;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class PropertyResolver {
+    private final ProfileActivationContext context;
+    private final Logger logger;
+    private Map<File, MavenProject> projectCache = new HashMap<>();
+    private Map<String, String> cache = new HashMap<>();
+
+
+    private PropertyResolver(ProfileActivationContext context, Logger logger) {
+        this.context = context;
+        this.logger = logger;
+    }
+
+    static final Pattern INTERPOLATION = Pattern.compile("\\$\\{([^\\}]+)\\}");
+
+    /**
+     * Fetches a named property value from current context.
+     *
+     * @param propertyName the property name to fetch.
+     */
+    String resolve(String propertyName) {
+        return resolveFromCache(propertyName, null);
+    }
+
+    private String resolveFromCache(String propertyName, Set<String> parents) {
+        if (parents != null && parents.contains(propertyName)) {
+            throw new IllegalArgumentException("Recursive property definition involving "+propertyName);
+        }
+        return cache.computeIfAbsent(propertyName, name -> resolve(name, parents == null ? new HashSet<>():parents));
+    }
+
+    private String resolve(String propertyName, Set<String> parents) {
+
+        // Fetch from -D parameter first
+        String value = context.getUserProperties().get(propertyName);
+        // Then fetch from project properties
+        if (value == null) {
+            value = context.getProjectProperties().get(propertyName);
+        }
+        // Then fetch from system properties
+        if (value == null) {
+            value = context.getSystemProperties().get(propertyName);
+        }
+        // If it's still null, try and hard load it from the project pom
+        if (value == null) {
+            value = getPropertyFromPom(context.getProjectDirectory(), propertyName);
+        }
+
+        // Interpolate any property references in the value:
+        if (value != null) {
+            Matcher interpolation = INTERPOLATION.matcher(value);
+            StringBuffer sb = new StringBuffer();
+            while (interpolation.find()) {
+                String inner = interpolation.group(1);
+                parents.add(propertyName);
+                interpolation.appendReplacement(sb, resolveFromCache(name, parents));
+                parents.remove(propertyName);
+            }
+            interpolation.appendTail(sb);
+        }
+        return value;
+    }
+
+    /**
+     * Will manually read the pom and any discoverable parent poms until a property
+     * is found.
+     */
+    private String getPropertyFromPom(File projectDirectory, String propertyName) {
+
+        // Look for the pom
+        File pomFile = new File(projectDirectory, "pom.xml");
+        if (!pomFile.exists()) {
+            logger.warn("No project file found at "+pomFile);
+            return null;
+        }
+
+        MavenProject project = projectCache.computeIfAbsent(pomFile, this::readMavenProject);
+        if (project == null) {
+            return null;
+        }
+
+        Object value;
+        if (propertyName.startsWith("project.")) {
+            // Fetch project properties from the model class
+            String fieldName = propertyName.substring(8, propertyName.length());
+            value = getViaReflection(project.getModel(), fieldName);
+            if (value == null && project.getModel().getParent() != null) {
+                value = getViaReflection(project.getModel().getParent(), fieldName);
+            }
+        } else {
+            value = project.getProperties().get(propertyName);
+        }
+        if (value != null) {
+            return value.toString();
+        } else {
+            // If the pom contains a parent block with a relativePath, use that to
+            // recursively search
+            if (project.getModel() != null && project.getModel().getParent() != null) {
+                String relativePath = project.getModel().getParent().getRelativePath().replace("pom.xml", "");
+                if (relativePath != null) {
+                    return getPropertyFromPom(new File(projectDirectory, relativePath), propertyName);
+                }
+            }
+        }
+        return null;
+    }
+
+    private MavenProject readMavenProject(File file) {
+        try (InputStream is = new FileInputStream(file)) {
+            MavenProject project = new MavenProject(new MavenXpp3Reader().read(is));
+            return project;
+        } catch (IOException | XmlPullParserException e) {
+            logger.warn("Could not read "+file, e);
+            return null;
+        }
+    }
+
+    /**
+     * Fetches a variable via reflection from a given object.
+     * @param object the object containing the value
+     * @param fieldName the name of the field
+     * @return the value if found, or null otherwise.
+     */
+    private static Object getViaReflection(Object object, String fieldName) {
+        try {
+            Field field = object.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(object);
+        } catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException
+                | SecurityException e) {
+            return null;
+        }
+    }
+
+    static PropertyResolver PREVIOUS = null;
+    static PropertyResolver get(ProfileActivationContext context, Logger logger) {
+        if (PREVIOUS != null && PREVIOUS.context.equals(context)) {
+            return PREVIOUS;
+        }
+        PREVIOUS = new PropertyResolver(context, logger);
+        return PREVIOUS;
+    }
+
+}

--- a/src/main/java/fish/payara/maven/extensions/regex/activator/RegexActivator.java
+++ b/src/main/java/fish/payara/maven/extensions/regex/activator/RegexActivator.java
@@ -37,24 +37,16 @@
  */
 package fish.payara.maven.extensions.regex.activator;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Field;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import org.apache.maven.model.Profile;
 import org.apache.maven.model.building.ModelProblemCollector;
-import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.model.profile.ProfileActivationContext;
 import org.apache.maven.model.profile.activation.ProfileActivator;
-import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 @Component(role = ExtensionActivator.class, hint = "Regex Profile Activator")
 public class RegexActivator implements ProfileActivator {
@@ -120,91 +112,10 @@ public class RegexActivator implements ProfileActivator {
      */
     private String getProperty(ProfileActivationContext context, String propertyName) {
         // First get actual property
+        // This is strange behavior that didn't move to common code
         String resolvedPropertyName = propertyName
                 .replaceAll("\\$\\{(.+)\\}", "$1");
 
-        // Fetch from -D parameter first
-        String value = context.getUserProperties().get(resolvedPropertyName);
-        // Then fetch from project properties
-        if (value == null) {
-            value = context.getProjectProperties().get(resolvedPropertyName);
-        }
-        // Then fetch from system properties
-        if (value == null) {
-            value = context.getSystemProperties().get(resolvedPropertyName);
-        }
-        // If it's still null, try and hard load it from the project pom
-        if (value == null) {
-            value = getPropertyFromPom(context.getProjectDirectory(), resolvedPropertyName);
-        }
-        
-        // If the property is equal to another property, fetch that one
-        if (value != null && value.startsWith("${") && value.endsWith("}")) {
-            return getProperty(context, value.substring(2, value.length() - 1));
-        }
-
-        return value;
+        return PropertyResolver.get(context, logger).resolve(propertyName);
     }
-
-    /**
-     * Will manually read the pom and any discoverable parent poms until a property
-     * is found.
-     */
-    private String getPropertyFromPom(File projectDirectory, String propertyName) {
-
-        // Look for the pom
-        File pomFile = new File(projectDirectory, "pom.xml");
-        if (!pomFile.exists()) {
-            return null;
-        }
-
-        // Read the pom file
-        try (InputStream is = new FileInputStream(pomFile)) {
-            MavenProject project = new MavenProject(new MavenXpp3Reader().read(is));
-            Object value;
-            if (propertyName.startsWith("project.")) {
-                // Fetch project properties from the model class
-                String fieldName = propertyName.substring(8, propertyName.length());
-                value = getViaReflection(project.getModel(), fieldName);
-                if (value == null && project.getModel().getParent() != null) {
-                    value = getViaReflection(project.getModel().getParent(), fieldName);
-                }
-            } else {
-                value = project.getProperties().get(propertyName);
-            }
-            if (value != null) {
-                return value.toString();
-            } else {
-                // If the pom contains a parent block with a relativePath, use that to
-                // recursively search
-                if (project.getModel() != null && project.getModel().getParent() != null) {
-                    String relativePath = project.getModel().getParent().getRelativePath().replace("pom.xml", "");
-                    if (relativePath != null) {
-                        return getPropertyFromPom(new File(projectDirectory, relativePath), propertyName);
-                    }
-                }
-            }
-        } catch (IOException | XmlPullParserException ex) {
-            logger.debug("Error reading project pom file.", ex);
-        }
-        return null;
-    }
-
-    /**
-     * Fetches a variable via reflection from a given object.
-     * @param object the object containing the value
-     * @param fieldName the name of the field
-     * @return the value if found, or null otherwise.
-     */
-    private static Object getViaReflection(Object object, String fieldName) {
-        try {
-            Field field = object.getClass().getDeclaredField(fieldName);
-            field.setAccessible(true);
-            return field.get(object);
-        } catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException
-                | SecurityException e) {
-            return null;
-        }
-    }
-
 }

--- a/src/main/java/fish/payara/maven/extensions/regex/activator/RegexActivator.java
+++ b/src/main/java/fish/payara/maven/extensions/regex/activator/RegexActivator.java
@@ -116,6 +116,6 @@ public class RegexActivator implements ProfileActivator {
         String resolvedPropertyName = propertyName
                 .replaceAll("\\$\\{(.+)\\}", "$1");
 
-        return PropertyResolver.get(context, logger).resolve(propertyName);
+        return PropertyResolver.get(context, logger).resolve(resolvedPropertyName);
     }
 }

--- a/src/main/java/fish/payara/maven/extensions/regex/activator/RegexActivator.java
+++ b/src/main/java/fish/payara/maven/extensions/regex/activator/RegexActivator.java
@@ -56,7 +56,7 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
-@Component(role = RegexActivator.class, hint = "Regex Profile Activator")
+@Component(role = ExtensionActivator.class, hint = "Regex Profile Activator")
 public class RegexActivator implements ProfileActivator {
 
     @Requirement

--- a/src/main/java/fish/payara/maven/extensions/regex/activator/VersionActivator.java
+++ b/src/main/java/fish/payara/maven/extensions/regex/activator/VersionActivator.java
@@ -73,14 +73,7 @@ public class VersionActivator implements ProfileActivator {
     }
 
     private String getPropertyValue(ProfileActivationContext context, String name) {
-        String value = context.getUserProperties().get( name );
-        if ( value  == null ) {
-            value = context.getProjectProperties().get( name );
-        }
-        if ( value == null ) {
-            value = context.getSystemProperties().get( name );
-        }
-        return value;
+        return PropertyResolver.get(context, logger).resolve(name);
     }
 
     @Override

--- a/src/main/java/fish/payara/maven/extensions/regex/activator/VersionActivator.java
+++ b/src/main/java/fish/payara/maven/extensions/regex/activator/VersionActivator.java
@@ -60,7 +60,7 @@ public class VersionActivator implements ProfileActivator {
     public boolean isActive(Profile profile, ProfileActivationContext context, ModelProblemCollector problems) {
         VersionRange range = parseSpec(profile);
         String value = getPropertyValue(context, profile.getActivation().getProperty().getName());
-        if (value == null) {
+        if (value == null || value.isEmpty()) {
             logger.warn("Did not find value of property "+profile.getActivation().getProperty().getName());
             return false;
         }

--- a/src/main/java/fish/payara/maven/extensions/regex/activator/VersionActivator.java
+++ b/src/main/java/fish/payara/maven/extensions/regex/activator/VersionActivator.java
@@ -1,0 +1,110 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.maven.extensions.regex.activator;
+
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.model.Profile;
+import org.apache.maven.model.building.ModelProblemCollector;
+import org.apache.maven.model.profile.ProfileActivationContext;
+import org.apache.maven.model.profile.activation.ProfileActivator;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
+
+@Component(role = ExtensionActivator.class, hint = "version-range", description = "Version Range Profile Activator")
+public class VersionActivator implements ProfileActivator {
+    @Requirement
+    private Logger logger;
+
+    @Override
+    public boolean isActive(Profile profile, ProfileActivationContext context, ModelProblemCollector problems) {
+        VersionRange range = parseSpec(profile);
+        String value = getPropertyValue(context, profile.getActivation().getProperty().getName());
+        if (value == null) {
+            logger.warn("Did not find value of property "+profile.getActivation().getProperty().getName());
+            return false;
+        }
+        DefaultArtifactVersion version = new DefaultArtifactVersion(value);
+        boolean result = range.containsVersion(version);
+        if (logger.isDebugEnabled()) {
+            logger.debug(String.format("Comparing %s against %s: %s", version, range, result ? "matches":"doesn't match"));
+        }
+        return result;
+    }
+
+    private String getPropertyValue(ProfileActivationContext context, String name) {
+        String value = context.getUserProperties().get( name );
+        if ( value  == null ) {
+            value = context.getProjectProperties().get( name );
+        }
+        if ( value == null ) {
+            value = context.getSystemProperties().get( name );
+        }
+        return value;
+    }
+
+    @Override
+    public boolean presentInConfig(Profile profile, ProfileActivationContext context, ModelProblemCollector problems) {
+        return parseSpec(profile) != null;
+    }
+
+    private VersionRange parseSpec(Profile profile) {
+        if (profile.getActivation() == null || profile.getActivation().getProperty() == null) {
+            return null;
+        }
+        String versionSpec = profile.getActivation().getProperty().getValue();
+        if (versionSpec != null) {
+            if (versionSpec.startsWith("=")) {
+                versionSpec = versionSpec.substring(1);
+            } else {
+                return null;
+            }
+            try {
+                return VersionRange.createFromVersionSpec(versionSpec);
+            } catch (InvalidVersionSpecificationException e) {
+                logger.warn("Invalid version range activation property "+versionSpec, e);
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
The feature works similar to regex activator. The format of `<value>` of the property is `=mavenVersionRange`, where maven version range is specified in [Maven API](https://maven.apache.org/ref/3.5.0/maven-artifact/apidocs/org/apache/maven/artifact/versioning/VersionRange.html#createFromVersionSpec(java.lang.String)).
Compared to regex activator it doesn't support interpolation in `<name>`.

So e.g. in order to activate profile when `payara.version` is `194-SNAPSHOT` or greater you'd use:

```
        <profile>
            <activation>
                <property>
                    <name>payara.version</name>
                    <value>=[5.194-SNAPSHOT,)</value>
                </property>
            </activation>
```
(note that 5.194 > 5.194-SNAPSHOT). Multiple version ranges can be separated by space.